### PR TITLE
replace subfigure package with subcaption

### DIFF
--- a/xmu-thesis-grd.cls
+++ b/xmu-thesis-grd.cls
@@ -376,7 +376,7 @@
 \RequirePackage{graphicx}
 
 %% 并列子图
-\RequirePackage{subfigure}
+\RequirePackage{subcaption}
 \RequirePackage{wrapfig}
 
 %% 设置图表标题选项


### PR DESCRIPTION
在从另外一个厦大论文模版迁移到该模版的过程中遇到了一些子图生成的问题，该PR目的为解决subfigure包导致的一些错误。

`subfigure`包已经很老了，更新一点的包应该是`subcaption`

subfigure包在调用如下命令时会产生 "Illegal unit of measure"的错误提示，而实际上该代码应该是没有错误的。

```latex
\begin{figure}
    \centering
    \begin{subfigure}[b]{0.3\textwidth}
        \includegraphics[scale=0.2]{image}
        \caption{A gull}
        \label{fig:gull}
    \end{subfigure}%
\end{figure}
```
具体讨论可见 Overleaf给出的错误排查[^1], 将`subfigure`替换为`subcaption`可解决该问题

[^1]: https://www.overleaf.com/learn/latex/Errors/Illegal_unit_of_measure_(pt_inserted)