### PR TITLE
修复目录排版错误

### DIFF
--- a/xmu-thesis-grd.cls
+++ b/xmu-thesis-grd.cls
@@ -78,7 +78,8 @@
 \def\xmu@label@enacknowledgements{Acknowledgements}
 \def\xmu@label@contents{目~~~~录}
 \def\xmu@label@compactcontents{目录}
-\def\xmu@label@encontents{Table of Contents}
+%\def\xmu@label@encontents{Table of Contents}
+\def\xmu@label@encontents{Contents}
 \def\xmu@label@encontentszh{Table of Contents in Chinese}
 % \def\xmu@label@encontentsen{Table of Contents in English}
 \def\xmu@label@encontentsen{Contents}

--- a/xmu-thesis-grd.cls
+++ b/xmu-thesis-grd.cls
@@ -80,7 +80,8 @@
 \def\xmu@label@compactcontents{目录}
 \def\xmu@label@encontents{Table of Contents}
 \def\xmu@label@encontentszh{Table of Contents in Chinese}
-\def\xmu@label@encontentsen{Table of Contents in English}
+% \def\xmu@label@encontentsen{Table of Contents in English}
+\def\xmu@label@encontentsen{Contents}
 \def\xmu@label@acronymlist{主要缩略词表}
 \def\xmu@label@symbollist{主要符号表}
 \def\xmu@label@enacronymlist{List of Acronyms}
@@ -645,7 +646,7 @@
 
 % 	\addtocontents{etoc}{\protect\contentsline{chapter}{\sffamily \encontentsname}{\sffamily \thepage}{chapter.\thechapter}} %将Contents加入到英文目录中
 	
-	\addcontentsline{etoc}{chapter}{\sffamily \xmu@label@encontentszh} %将中文目录加入到英文目录中
+	% \addcontentsline{etoc}{chapter}{\sffamily \xmu@label@encontentszh} %将中文目录加入到英文目录中
 % 	\addtocontents{etoc}{\protect\contentsline{chapter}{\sffamily \encontentsname}{\thepage}{chapter.\thechapter}} %将Contents加入到英文目录中
 	
 	\makeatletter
@@ -683,7 +684,7 @@
 	
 	\markboth{\encontentsname}{\encontentsname} % 修改页眉文字
 
-	\addcontentsline{toc}{chapter}{\xmu@label@encontents} % 将英文目录加入到中文目录中
+	% \addcontentsline{toc}{chapter}{\xmu@label@encontents} % 将英文目录加入到中文目录中
 	\addcontentsline{etoc}{chapter}{\sffamily \xmu@label@encontentsen} % 将英文目录加入到英文目录中
 	
 	\makeatletter


### PR DESCRIPTION
现有的repo在渲染目录时，会出现：
中文目录：
![image](https://github.com/user-attachments/assets/fe1dc9da-677b-4d45-adef-297f1a8dfd19)
英文目录：
![image](https://github.com/user-attachments/assets/42a1e8c4-801d-45e5-b87c-dd21ca97fd3c)
根据我从学校论文库里下载的信息学院硕士论文来看，目录对应为这样：
中文目录：
![image](https://github.com/user-attachments/assets/3eb9bbac-7695-45a4-bea0-6452395b63db)
英文目录：
![image](https://github.com/user-attachments/assets/11178210-0aba-4124-a572-b35063fad6fa)
所以提出修复PR