### PR TITLE
按照信息学院手册修复参考文献风格

### DIFF
--- a/xmu-thesis-grd.cls
+++ b/xmu-thesis-grd.cls
@@ -751,7 +751,7 @@
 %% 参考文献风格
 \RequirePackage[sort&compress]{gbt7714}
 \bibliographystyle{reference/gbt7714-numerical} 
-\citestyle{numbers}
+\citestyle{super}
 
 %% 引用文献序号的排序与压缩
 \newcommand{\supercite}[1]{{\citestyle{super}\cite{#1}}} % 上标引用


### PR DESCRIPTION
按照[厦门大学信息学院研究生学位论文写作指南(2024.05）.pdf](https://informatics.xmu.edu.cn/system/_content/download.jsp?urltype=news.DownloadAttachUrl&owner=1480852315&wbfileid=C1DC3C4D4B54141BCEA384EE45986E97) 里的 `3.4 参考文献标注法 `
![image](https://github.com/user-attachments/assets/21750cd6-86b1-496a-9efc-00fdec19040e)
修复模板默认采用 `顺序编码制` ，更加简洁
修复前：
![image](https://github.com/user-attachments/assets/6c3eb392-3fb3-4efb-9e71-b82cbc1c1cfc)
修复后：
![image](https://github.com/user-attachments/assets/4eb56a26-eb7f-494a-ada3-ca5fca611eba)
